### PR TITLE
Update plan.sh to use newer pkg_version

### DIFF
--- a/plan.sh
+++ b/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=imagemagick
 pkg_origin=franklinwebber
-pkg_version=6.9.2-10
+pkg_version=7.0.8-49
 pkg_description="A software suite to create, edit, compose, or convert bitmap images."
 pkg_upstream_url="http://imagemagick.org/"
 pkg_license=('Apache2')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source=http://www.imagemagick.org/download/releases/ImageMagick-${pkg_version}.tar.xz
-pkg_shasum=da2f6fba43d69f20ddb11783f13f77782b0b57783dde9cda39c9e5e733c2013c
+pkg_shasum=3ab140e46390e63731298d7ddb21c06d4a21cf09673b2e911aea605f4489cbab
 pkg_deps=(core/glibc core/zlib core/libpng core/xz core/gcc-libs core/libjpeg-turbo)
 pkg_build_deps=(core/zlib core/coreutils core/diffutils core/patch core/make core/gcc core/sed core/glibc core/pkg-config core/libjpeg-turbo)
 pkg_bin_dirs=(bin)


### PR DESCRIPTION
This PR changes the version number from 6.9.2-10 to 7.0.8-49(the latest stable release). It also updates the pkg_shasum. This change was made in order to satisfy conflicting pkg dependency issues between imagemagick, and the newer ruby pkg being used for piedmont.